### PR TITLE
SXSD-6480: Remove reference to ReferenceData.standard() from customised classes.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>com.opengamma.strata</groupId>
   <artifactId>strata-examples</artifactId>
-  <version>2.12.22-xplain-2</version>
+  <version>2.12.22-xplain-3</version>
   <packaging>jar</packaging>
   <name>Strata-Examples</name>
   <description>Example code to demonstrate use of Strata</description>

--- a/modules/basics/pom.xml
+++ b/modules/basics/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-basics</artifactId>
@@ -19,6 +19,12 @@
     <dependency>
       <groupId>com.opengamma.strata</groupId>
       <artifactId>strata-collect</artifactId>
+    </dependency>
+
+    <!-- Third Party -->
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
 
     <!-- Testing -->

--- a/modules/basics/src/main/java/com/opengamma/strata/basics/ReferenceDataHolder.java
+++ b/modules/basics/src/main/java/com/opengamma/strata/basics/ReferenceDataHolder.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2023 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.basics;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.opengamma.strata.collect.ArgChecker;
+
+/**
+ * Associates {@link ReferenceData} with the current execution thread.
+ * <p>
+ * This class provides a series of static methods that delegate to {@link InheritableThreadLocalReferenceDataHolderStrategy}.
+ * This strategy uses an {@link InheritableThreadLocal} to store {@code ReferenceData} against a thread.
+ *
+ * </p>
+ */
+public class ReferenceDataHolder {
+  private ReferenceDataHolder() {
+    // prevent instantiation
+  }
+
+  private static final InheritableThreadLocalReferenceDataHolderStrategy STRATEGY = new InheritableThreadLocalReferenceDataHolderStrategy();
+
+  /**
+   * Sets the current reference data for this thread.
+   *
+   * @param refData the new value to hold (should never be null).
+   * @throws IllegalArgumentException if {@code refData} is null.
+   */
+  public static void setReferenceData(ReferenceData refData) {
+    ArgChecker.notNull(refData, "refData");
+    STRATEGY.setReferenceData(refData);
+  }
+
+  /**
+   * Gets the current reference data for this thread.
+   * If it has not previously been set for this thread then it will be null.
+   *
+   * @return current reference data
+   */
+  public static ReferenceData getReferenceData() {
+    return STRATEGY.getReferenceData();
+  }
+
+  /**
+   * Gets the current reference data for this thread and, if it is not set, return a fallback value instead.
+   *
+   * @param other the fallback value to return if the reference data has not been set for this thread (should never be null).
+   * @return the reference data for this thread, or the provided fallback value
+   * @throws IllegalArgumentException if {@code other} is null.
+   */
+  public static ReferenceData getReferenceDataWithFallback(ReferenceData other) {
+    ArgChecker.notNull(other, "other");
+    return STRATEGY.getReferenceDataWithFallback(other);
+  }
+
+  /**
+   * Executes a function to return a value with reference data set for the duration of the function and then
+   * cleared afterwards.
+   *
+   * @param referenceData the new value to hold (should never be null).
+   * @param fn the function to call to return a value
+   * @return the value returned from the function
+   * @param <T> type of value
+   */
+  public static <T> T withReferenceData(ReferenceData referenceData, Supplier<T> fn) {
+    setReferenceData(referenceData);
+    try {
+      T result = fn.get();
+      return result;
+    } finally {
+      clearReferenceData();
+    }
+  }
+
+  /**
+   * Executes a function that returns no value with reference data set for the duration of the function and then
+   * cleared afterwards.
+   *
+   * @param referenceData the new value to hold (should never be null).
+   * @param fn the function to call
+   */
+  public static void withReferenceData(ReferenceData referenceData, Runnable fn) {
+    setReferenceData(referenceData);
+    try {
+      fn.run();
+    } finally {
+      clearReferenceData();
+    }
+  }
+
+  /**
+   * Clears the current reference data for this thread.
+   */
+  public static void clearReferenceData() {
+    STRATEGY.clearReferenceData();
+  }
+
+  private static class InheritableThreadLocalReferenceDataHolderStrategy {
+    private Logger log = LoggerFactory.getLogger(ReferenceDataHolder.class);
+    private static final ThreadLocal<ReferenceData> HOLDER = new InheritableThreadLocal<>();
+
+    public void clearReferenceData() {
+      HOLDER.remove();
+    }
+
+    public ReferenceData getReferenceData() {
+      return HOLDER.get();
+    }
+
+    public void setReferenceData(ReferenceData refData) {
+      HOLDER.set(refData);
+    }
+
+    public ReferenceData getReferenceDataWithFallback(ReferenceData other) {
+      final ReferenceData result = getReferenceData();
+      if (result == null) {
+        log.warn("No reference data saved in thread, falling back to default.");
+        return other;
+      }
+      return result;
+    }
+  }
+}

--- a/modules/calc/pom.xml
+++ b/modules/calc/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-calc</artifactId>

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import com.opengamma.strata.basics.ReferenceDataHolder;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaBean;
@@ -30,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import com.opengamma.strata.basics.CalculationTarget;
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.ReferenceDataHolder;
 import com.opengamma.strata.basics.ReferenceDataNotFoundException;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyPair;

--- a/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
+++ b/modules/calc/src/main/java/com/opengamma/strata/calc/runner/CalculationTask.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import com.opengamma.strata.basics.ReferenceDataHolder;
 import org.joda.beans.ImmutableBean;
 import org.joda.beans.JodaBeanUtils;
 import org.joda.beans.MetaBean;
@@ -231,7 +232,9 @@ public final class CalculationTask implements ImmutableBean {
       Set<Measure> measures = Sets.intersection(requestedMeasures, supportedMeasures);
       Map<Measure, Result<?>> map = ImmutableMap.of();
       if (!measures.isEmpty()) {
-        map = function.calculate(target, measures, parameters, marketData, refData);
+        // TODO: everything should ideally be resolved in the CalculationFunction, not relying on ReferenceDataHolder lower down.
+        map = ReferenceDataHolder.withReferenceData(refData,
+            () -> function.calculate(target, measures, parameters, marketData, refData));
       }
       // check if result does not contain all requested measures
       if (!map.keySet().containsAll(requestedMeasures)) {

--- a/modules/collect/pom.xml
+++ b/modules/collect/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-collect</artifactId>

--- a/modules/data/pom.xml
+++ b/modules/data/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-data</artifactId>

--- a/modules/loader/pom.xml
+++ b/modules/loader/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-loader</artifactId>

--- a/modules/market/pom.xml
+++ b/modules/market/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-market</artifactId>

--- a/modules/math/pom.xml
+++ b/modules/math/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-math</artifactId>

--- a/modules/measure/pom.xml
+++ b/modules/measure/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-measure</artifactId>

--- a/modules/pom.xml
+++ b/modules/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>com.opengamma.strata</groupId>
   <artifactId>strata-parent</artifactId>
-  <version>2.12.22-xplain-2</version>
+  <version>2.12.22-xplain-3</version>
   <packaging>pom</packaging>
   <name>Strata-Parent</name>
   <description>OpenGamma Strata Parent</description>

--- a/modules/pricer/pom.xml
+++ b/modules/pricer/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-pricer</artifactId>

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/DiscountFxForwardRates.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/fx/DiscountFxForwardRates.java
@@ -26,6 +26,7 @@ import org.joda.beans.impl.direct.DirectMetaPropertyMap;
 import org.joda.beans.impl.direct.DirectPrivateBeanBuilder;
 
 import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.ReferenceDataHolder;
 import com.opengamma.strata.basics.currency.Currency;
 import com.opengamma.strata.basics.currency.CurrencyAmount;
 import com.opengamma.strata.basics.currency.CurrencyPair;
@@ -152,7 +153,8 @@ public final class DiscountFxForwardRates
   private LocalDate spotDate() {
     try {
       FxSwapConvention fxSwapConvention = FxSwapConvention.of(currencyPair);
-      return fxSwapConvention.calculateSpotDateFromTradeDate(valuationDate, ReferenceData.standard());
+      ReferenceData refData = ReferenceDataHolder.getReferenceDataWithFallback(ReferenceData.standard());
+      return fxSwapConvention.calculateSpotDateFromTradeDate(valuationDate, refData);
     } catch (IllegalArgumentException e) {
       return valuationDate;
     }

--- a/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/swap/FxDfScaler.java
+++ b/modules/pricer/src/main/java/com/opengamma/strata/pricer/impl/swap/FxDfScaler.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.strata.pricer.impl.swap;
+
+import java.time.LocalDate;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.currency.CurrencyPair;
+import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.product.fx.type.FxSwapConvention;
+
+/**
+ * Utility method to scale a discount factor, used by both {@link DiscountingFxResetNotionalExchangePricer} and
+ * {@link DiscountingRatePaymentPeriodPricer}.
+ */
+public final class FxDfScaler {
+
+  private FxDfScaler() {
+    // prevent instantiation
+  }
+
+  /**
+   * Scale a discount factor by the ratio between base and counter currencies at the spot date.
+   *
+   * @param provider        the rates provider
+   * @param refData         the reference data, used to resolve the spot date from the valuation date
+   * @param baseCurrency    the base currency
+   * @param counterCurrency the counter currency
+   * @param df              the unscaled discount factor
+   * @return the discount factor scaled by the ratio between base and counter currency discount factors at the spot date
+   */
+  static double scaledDf(RatesProvider provider, ReferenceData refData, Currency baseCurrency, Currency counterCurrency, double df) {
+    LocalDate valuationDate = provider.getValuationDate();
+    LocalDate spotDate = FxSwapConvention.of(CurrencyPair.of(baseCurrency, counterCurrency)).calculateSpotDateFromTradeDate(valuationDate,
+        refData);
+
+    double dfCounterSpot = provider.discountFactor(counterCurrency, spotDate);
+    double dfReferenceSpot = provider.discountFactor(baseCurrency, spotDate);
+    double dfScaled = (df / dfCounterSpot) * dfReferenceSpot;
+    return dfScaled;
+  }
+}

--- a/modules/product/pom.xml
+++ b/modules/product/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-product</artifactId>

--- a/modules/report/pom.xml
+++ b/modules/report/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.opengamma.strata</groupId>
     <artifactId>strata-parent</artifactId>
-    <version>2.12.22-xplain-2</version>
+    <version>2.12.22-xplain-3</version>
     <relativePath>..</relativePath>
   </parent>
   <artifactId>strata-report</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   </parent>
   <groupId>com.opengamma.strata</groupId>
   <artifactId>strata-root</artifactId>
-  <version>2.12.22-xplain-2</version>
+  <version>2.12.22-xplain-3</version>
   <packaging>pom</packaging>
   <name>Strata-Root</name>
   <description>OpenGamma Strata root</description>


### PR DESCRIPTION


ReferenceData is passed as a ThreadLocal using ReferenceDataHolder down from the CalculationTask, or if pricers are used more directly then ReferenceDataHolder can be initialised externally.